### PR TITLE
pre-exclude regex for files

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,28 +5,26 @@ module.exports = transformTools.makeRequireTransform(
     "fite-browserify-aws-sdk",
     {
         evaluateArguments: true,
-        includeExtensions: [ "js" ]
+        regex: /[\/\\]aws-sdk[\/\\]lib[\/\\]aws\.js$/
     },
     function (args, opts, cb) {
-        if (opts.file.match(/[\/\\]aws-sdk[\/\\]lib[\/\\]aws\.js$/)) {
-            switch (args[0]) {
-                case "./api_loader":
-                    return cb(null, "{ load: function(svc, version) { return AWS.apiLoader.services[svc][version]; } }");
-                case "./services":
-                    var services = opts.config.services;
-                    if (services instanceof Array) {
-                        services = services.join(",");
-                    }
-                    if (services === undefined) {
-                        services = "all";
-                    }
-                    var inject = "AWS.apiLoader.services = {};\n";
-                    if (services) {
-                        var collector = require(path.resolve(path.dirname(opts.file), "../dist-tools/service-collector"));
-                        inject += collector(services);
-                    }
-                    return cb(null, inject);
-            }
+        switch (args[0]) {
+            case "./api_loader":
+                return cb(null, "{ load: function(svc, version) { return AWS.apiLoader.services[svc][version]; } }");
+            case "./services":
+                var services = opts.config.services;
+                if (services instanceof Array) {
+                    services = services.join(",");
+                }
+                if (services === undefined) {
+                    services = "all";
+                }
+                var inject = "AWS.apiLoader.services = {};\n";
+                if (services) {
+                    var collector = require(path.resolve(path.dirname(opts.file), "../dist-tools/service-collector"));
+                    inject += collector(services);
+                }
+                return cb(null, inject);
         }
         return cb();
     }


### PR DESCRIPTION
Including the `jws` library (from `jsonwebtoken`) was causing the following error, bailing out before it gets to this file corrects the behavior.

```
SyntaxError: Unexpected token (2:6) (while fite-browserify-aws-sdk was processing ./node_modules/jws/index.js) while parsing file: ./node_modules/jws/index.js
```
